### PR TITLE
Changed way oc cli is downloaded (#115)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1420,6 +1420,11 @@
         "path-to-regexp": "^1.7.0"
       }
     },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,22 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@octokit/rest": {
-      "version": "15.15.1",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.15.1.tgz",
-      "integrity": "sha512-TnuzjE880qbknEFAVqEr3VeOcE0yXo0kJEW+EK8TASpzMbykKCydei6WUmDSV3bq7aI+llkMrBYes1kIjpU7fA==",
-      "requires": {
-        "before-after-hook": "^1.1.0",
-        "btoa-lite": "^1.0.0",
-        "debug": "^3.1.0",
-        "http-proxy-agent": "^2.1.0",
-        "https-proxy-agent": "^2.2.0",
-        "lodash": "^4.17.4",
-        "node-fetch": "^2.1.1",
-        "universal-user-agent": "^2.0.0",
-        "url-template": "^2.0.8"
-      }
-    },
     "@sinonjs/commons": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
@@ -145,14 +129,6 @@
       "version": "0.4.13",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
       "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw=="
-    },
-    "agent-base": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
-      "requires": {
-        "es6-promisify": "^5.0.0"
-      }
     },
     "amdefine": {
       "version": "1.0.1",
@@ -284,11 +260,6 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
       "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
     },
-    "before-after-hook": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.1.0.tgz",
-      "integrity": "sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA=="
-    },
     "bit-mask": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bit-mask/-/bit-mask-1.0.2.tgz",
@@ -321,11 +292,6 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
-    },
-    "btoa-lite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
-      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
     },
     "buffer": {
       "version": "3.6.0",
@@ -538,14 +504,6 @@
       "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
       "dev": true
     },
-    "debug": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-      "requires": {
-        "ms": "^2.1.1"
-      }
-    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -684,15 +642,8 @@
     "es6-promise": {
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
-      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "requires": {
-        "es6-promise": "^4.0.3"
-      }
+      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -917,6 +868,7 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
+<<<<<<< HEAD
     "http-proxy-agent": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
@@ -948,6 +900,30 @@
       "requires": {
         "agent-base": "^4.1.0",
         "debug": "^3.1.0"
+=======
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "dev": true
+    },
+    "husky": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-1.1.1.tgz",
+      "integrity": "sha512-D8ly8eIZdWzWVG4mh4apaX1PP47uLSaN8CS0RyuuLtHJ20Gt6Ccky5pSecaPsqxNzQj0zon3x6QX/0kCc5/TOQ==",
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "^5.0.6",
+        "execa": "^0.9.0",
+        "find-up": "^3.0.0",
+        "get-stdin": "^6.0.0",
+        "is-ci": "^1.2.1",
+        "pkg-dir": "^3.0.0",
+        "please-upgrade-node": "^3.1.1",
+        "read-pkg": "^4.0.1",
+        "run-node": "^1.0.0",
+        "slash": "^2.0.0"
+>>>>>>> cleaned proj (#115)
       }
     },
     "ieee754": {
@@ -1198,10 +1174,22 @@
       "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
       "dev": true
     },
+<<<<<<< HEAD
     "macos-release": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-1.1.0.tgz",
       "integrity": "sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA=="
+=======
+    "lru-cache": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+>>>>>>> cleaned proj (#115)
     },
     "make-dir": {
       "version": "1.3.0",
@@ -1401,11 +1389,6 @@
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
     },
-    "ms": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-    },
     "ncp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
@@ -1436,11 +1419,6 @@
         "lolex": "^4.1.0",
         "path-to-regexp": "^1.7.0"
       }
-    },
-    "node-fetch": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
-      "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA=="
     },
     "nopt": {
       "version": "3.0.6",
@@ -1559,15 +1537,6 @@
             "pump": "^3.0.0"
           }
         }
-      }
-    },
-    "os-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
-      "integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4=",
-      "requires": {
-        "macos-release": "^1.0.0",
-        "win-release": "^1.0.0"
       }
     },
     "p-defer": {
@@ -2175,23 +2144,10 @@
         "through": "^2.3.6"
       }
     },
-    "universal-user-agent": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.0.1.tgz",
-      "integrity": "sha512-vz+heWVydO0iyYAa65VHD7WZkYzhl7BeNVy4i54p4TF8OMiLSXdbuQe4hm+fmWAsL+rVibaQHXfhvkw3c1Ws2w==",
-      "requires": {
-        "os-name": "^2.0.1"
-      }
-    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
-    },
-    "url-template": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
-      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
     },
     "util": {
       "version": "0.10.4",
@@ -2244,14 +2200,6 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
-    },
-    "win-release": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
-      "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
-      "requires": {
-        "semver": "^5.0.1"
-      }
     },
     "wolfy87-eventemitter": {
       "version": "5.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -868,64 +868,6 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
-<<<<<<< HEAD
-    "http-proxy-agent": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-      "requires": {
-        "agent-base": "4",
-        "debug": "3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
-    },
-    "https-proxy-agent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
-      "requires": {
-        "agent-base": "^4.1.0",
-        "debug": "^3.1.0"
-=======
-    "hosted-git-info": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
-      "dev": true
-    },
-    "husky": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-1.1.1.tgz",
-      "integrity": "sha512-D8ly8eIZdWzWVG4mh4apaX1PP47uLSaN8CS0RyuuLtHJ20Gt6Ccky5pSecaPsqxNzQj0zon3x6QX/0kCc5/TOQ==",
-      "dev": true,
-      "requires": {
-        "cosmiconfig": "^5.0.6",
-        "execa": "^0.9.0",
-        "find-up": "^3.0.0",
-        "get-stdin": "^6.0.0",
-        "is-ci": "^1.2.1",
-        "pkg-dir": "^3.0.0",
-        "please-upgrade-node": "^3.1.1",
-        "read-pkg": "^4.0.1",
-        "run-node": "^1.0.0",
-        "slash": "^2.0.0"
->>>>>>> cleaned proj (#115)
-      }
-    },
     "ieee754": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
@@ -1173,23 +1115,6 @@
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
       "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
       "dev": true
-    },
-<<<<<<< HEAD
-    "macos-release": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-1.1.0.tgz",
-      "integrity": "sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA=="
-=======
-    "lru-cache": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
-      "dev": true,
-      "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
->>>>>>> cleaned proj (#115)
     },
     "make-dir": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "decompress": "^4.2.0",
     "decompress-targz": "^4.1.1",
     "fs-extra": "^7.0.0",
+    "node-fetch": "^2.6.0",
     "q": "^1.5.1",
     "substituter": "^1.3.0",
     "valid-url": "^1.0.9",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   },
   "homepage": "https://github.com/redhat-developer/openshift-vsts#readme",
   "dependencies": {
-    "@octokit/rest": "^15.12.1",
     "@types/fs-extra": "^5.0.4",
     "@types/q": "^1.5.1",
     "@types/valid-url": "^1.0.2",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,7 +11,10 @@ export const LATEST = 'latest';
 export const OC_TAR_GZ = 'oc.tar.gz';
 export const OC_ZIP = 'oc.zip';
 
-export const OPENSHIFT_LATEST_VERSION: Map<string, string> = new Map<string, string>();
+export const OPENSHIFT_LATEST_VERSION: Map<string, string> = new Map<
+  string,
+  string
+>();
 OPENSHIFT_LATEST_VERSION.set('3.3', '3.3.1.46.45');
 OPENSHIFT_LATEST_VERSION.set('3.4', '3.4.1.44.57');
 OPENSHIFT_LATEST_VERSION.set('3.5', '3.5.5');

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,10 @@
+
+export const OPENSHIFT_V3_BASE_URL = 'https://mirror.openshift.com/pub/openshift-v3/clients/';
+export const OPENSHIFT_V4_BASE_URL = 'https://mirror.openshift.com/pub/openshift-v4/clients/oc/';
+
+export const LINUX = 'linux';
+export const MACOSX = 'macosx';
+export const WIN = 'windows';
+
+export const OC_TAR_GZ = 'oc.tar.gz';
+export const OC_ZIP = 'oc.zip'; 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
-
-export const OPENSHIFT_V3_BASE_URL = 'https://mirror.openshift.com/pub/openshift-v3/clients';
-export const OPENSHIFT_V4_BASE_URL = 'https://mirror.openshift.com/pub/openshift-v4/clients/oc';
+export const OPENSHIFT_V3_BASE_URL =
+  'https://mirror.openshift.com/pub/openshift-v3/clients';
+export const OPENSHIFT_V4_BASE_URL =
+  'https://mirror.openshift.com/pub/openshift-v4/clients/oc';
 
 export const LINUX = 'linux';
 export const MACOSX = 'macosx';
@@ -8,4 +9,15 @@ export const WIN = 'windows';
 export const LATEST = 'latest';
 
 export const OC_TAR_GZ = 'oc.tar.gz';
-export const OC_ZIP = 'oc.zip'; 
+export const OC_ZIP = 'oc.zip';
+
+export const OPENSHIFT_LATEST_VERSION: Map<string, string> = new Map<string, string>();
+OPENSHIFT_LATEST_VERSION.set('3.3', '3.3.1.46.45');
+OPENSHIFT_LATEST_VERSION.set('3.4', '3.4.1.44.57');
+OPENSHIFT_LATEST_VERSION.set('3.5', '3.5.5');
+OPENSHIFT_LATEST_VERSION.set('3.6', '3.6');
+OPENSHIFT_LATEST_VERSION.set('3.7', '3.7.126');
+OPENSHIFT_LATEST_VERSION.set('3.8', '3.8.46');
+OPENSHIFT_LATEST_VERSION.set('3.9', '3.9.103');
+OPENSHIFT_LATEST_VERSION.set('3.10', '3.10.183');
+OPENSHIFT_LATEST_VERSION.set('3.11', '3.11.154');

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,10 +1,11 @@
 
-export const OPENSHIFT_V3_BASE_URL = 'https://mirror.openshift.com/pub/openshift-v3/clients/';
-export const OPENSHIFT_V4_BASE_URL = 'https://mirror.openshift.com/pub/openshift-v4/clients/oc/';
+export const OPENSHIFT_V3_BASE_URL = 'https://mirror.openshift.com/pub/openshift-v3/clients';
+export const OPENSHIFT_V4_BASE_URL = 'https://mirror.openshift.com/pub/openshift-v4/clients/oc';
 
 export const LINUX = 'linux';
 export const MACOSX = 'macosx';
 export const WIN = 'windows';
+export const LATEST = 'latest';
 
 export const OC_TAR_GZ = 'oc.tar.gz';
 export const OC_ZIP = 'oc.zip'; 

--- a/src/oc-install.ts
+++ b/src/oc-install.ts
@@ -99,7 +99,7 @@ export class InstallHandler {
   static async latestStable(osType: string): Promise<string | null> {
     tl.debug('determining latest oc version');
 
-    const bundle = await this.getOcBundleByOS(osType);
+    const bundle = await InstallHandler.getOcBundleByOS(osType);
     if (!bundle) {
       tl.debug('Unable to find bundle url');
       return null;

--- a/src/oc-install.ts
+++ b/src/oc-install.ts
@@ -267,6 +267,7 @@ export class InstallHandler {
       case '.tgz':
       case '.tar.gz': {
         await decompress(archivePath, downloadDir, {
+          filter: file => file.data.length > 0,
           plugins: [decompressTargz()]
         });
         break;

--- a/src/oc-install.ts
+++ b/src/oc-install.ts
@@ -119,7 +119,8 @@ export class InstallHandler {
 
     let url: string = '';
     // determine the base_url based on version
-    const vMajorRegEx: RegExpExecArray = new RegExp('\d+(?=\.)').exec(version);
+    const reg = new RegExp('\\d+(?=\\.)');
+    const vMajorRegEx: RegExpExecArray = reg.exec(version);
     if (!vMajorRegEx || vMajorRegEx.length === 0) {
       tl.debug('Error retrieving version');
       return null;
@@ -148,7 +149,7 @@ export class InstallHandler {
   }
 
   static async getOcBundleByOS(osType: string): Promise<string | null> {
-    let url: string;
+    let url: string = '';
 
     // determine the bundle path based on the OS type
     switch (osType) {

--- a/src/oc-install.ts
+++ b/src/oc-install.ts
@@ -173,7 +173,7 @@ export class InstallHandler {
       return null;
     }
 
-    const bundle = await this.getOcBundleByOS(osType);
+    const bundle = await InstallHandler.getOcBundleByOS(osType);
     if (!bundle) {
       tl.debug('Unable to find bundle url');
       return null;

--- a/src/oc-install.ts
+++ b/src/oc-install.ts
@@ -11,15 +11,6 @@ const validUrl = require('valid-url');
 const decompress = require('decompress');
 const decompressTargz = require('decompress-targz');
 const Zip = require('adm-zip');
-//const octokit = require('@octokit/rest')();
-
-// if (process.env['GITHUB_ACCESS_TOKEN']) {
-//   tl.debug('using octokit with token based authentication');
-//   octokit.authenticate({
-//     type: 'token',
-//     token: process.env['GITHUB_ACCESS_TOKEN']
-//   });
-// }
 
 export class InstallHandler {
   /**
@@ -47,9 +38,7 @@ export class InstallHandler {
       if (downloadVersion === null) {
         return Promise.reject('Unable to determine latest oc download URL');
       }
-    }
-
-    
+    }    
 
     tl.debug('creating download directory');
     let downloadDir =

--- a/tasks/config-map/task.json
+++ b/tasks/config-map/task.json
@@ -65,7 +65,7 @@
     {
       "name": "uselocalOc",
       "type": "boolean",
-      "label": "use local oc executable",
+      "label": "Use local oc executable",
       "defaultValue": "false",
       "required": false,
       "helpMarkDown": "Check if oc is already installed in the machine and use that if available"

--- a/tasks/oc-cmd/task.json
+++ b/tasks/oc-cmd/task.json
@@ -54,7 +54,7 @@
     {
       "name": "uselocalOc",
       "type": "boolean",
-      "label": "use local oc executable",
+      "label": "Use local oc executable",
       "defaultValue": "false",
       "required": false,
       "helpMarkDown": "Check if oc is already installed in the machine and use that if available"

--- a/test/oc-install.test.ts
+++ b/test/oc-install.test.ts
@@ -57,35 +57,6 @@ describe('InstallHandler', function() {
       }
     });
 
-    it('check if ocBundleURl is called if version number is passed as input', async function() {
-      sandbox.stub(fs, 'existsSync').returns(true);
-      const bundleStub = sandbox
-        .stub(InstallHandler, 'ocBundleURL')
-        .resolves(
-          'https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.1/windows/oc.zip'
-        );
-      sandbox.stub(InstallHandler, 'downloadAndExtract').resolves('path');
-      await InstallHandler.installOc('4.1', 'Windows_NT', false);
-      expect(bundleStub.calledOnce).to.be.true;
-    });
-
-    it('check if ocBundleURl is called twice if version number release as input is not valid', async function() {
-      sandbox.stub(fs, 'existsSync').returns(true);
-      const bundleStub = sandbox
-        .stub(InstallHandler, 'ocBundleURL')
-        .onFirstCall()
-        .resolves(
-          'https://mirror.openshift.com/pub/openshift-v4/clients/oc/3.1/windows/oc.zip'
-        )
-        .onSecondCall()
-        .resolves(
-          'https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.1/windows/oc.zip'
-        );
-      sandbox.stub(InstallHandler, 'downloadAndExtract').resolves('path');
-      await InstallHandler.installOc('4.1', 'Windows_NT', false);
-      expect(bundleStub.calledTwice).to.be.true;
-    });
-
     it('check if ocBundle is not called if uri is valid', async function() {
       sandbox.stub(fs, 'existsSync').returns(true);
       const ocBundleStub = sandbox.stub(InstallHandler, 'ocBundleURL');
@@ -96,24 +67,6 @@ describe('InstallHandler', function() {
         false
       );
       expect(ocBundleStub.calledOnce).to.be.false;
-    });
-
-    it('return error if url retrieved by version number is null', async function() {
-      sandbox.stub(fs, 'existsSync').returns(true);
-      sandbox
-        .stub(InstallHandler, 'ocBundleURL')
-        .onFirstCall()
-        .resolves(
-          'https://mirror.openshift.com/pub/openshift-v4/clients/oc/3.1/windows/oc.zip'
-        )
-        .onSecondCall()
-        .resolves(null);
-      try {
-        await InstallHandler.installOc('4.1', 'Windows_NT', false);
-        expect.fail();
-      } catch (ex) {
-        expect(ex).equals('Unable to determine oc download URL.');
-      }
     });
 
     it('check if task fails if downloadAndExtract doesnt return a valid ocBinary', async function() {

--- a/test/oc-install.test.ts
+++ b/test/oc-install.test.ts
@@ -10,6 +10,7 @@ import * as validUrl from 'valid-url';
 
 import tl = require('vsts-task-lib/task');
 import { IExecSyncResult } from 'vsts-task-lib/toolrunner';
+import { OPENSHIFT_V4_BASE_URL, LATEST, LINUX, OC_TAR_GZ, WIN, OC_ZIP, MACOSX } from '../src/constants';
 
 describe('InstallHandler', function() {
   let sandbox: sinon.SinonSandbox;
@@ -37,6 +38,37 @@ describe('InstallHandler', function() {
       expect(latestStub.calledOnce).to.be.true;
     });
 
+    it('return error if lastest version is not found', async function() {
+      sandbox.stub(InstallHandler, 'latestStable').resolves(null);
+      try {
+        await InstallHandler.installOc('', 'Darwin', false);
+        expect.fail();
+      } catch (ex) {
+        expect(ex).equals('Unable to determine latest oc download URL');
+      }
+    });
+
+    it('check if ocBundleURl is called if version number is passed as input', async function() {
+      sandbox.stub(fs, 'existsSync').returns(true);
+      const bundleStub = sandbox.stub(InstallHandler, 'ocBundleURL')
+                                .resolves('https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.1/windows/oc.zip');
+      sandbox.stub(InstallHandler, 'downloadAndExtract').resolves('path');
+      await InstallHandler.installOc('4.1', 'Windows_NT', false);
+      expect(bundleStub.calledOnce).to.be.true;
+    });
+
+    it('check if ocBundleURl is called twice if version number release as input is not valid', async function() {
+      sandbox.stub(fs, 'existsSync').returns(true);
+      const bundleStub = sandbox.stub(InstallHandler, 'ocBundleURL')
+                                .onFirstCall()
+                                .resolves('https://mirror.openshift.com/pub/openshift-v4/clients/oc/3.1/windows/oc.zip')
+                                .onSecondCall()
+                                .resolves('https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.1/windows/oc.zip');
+      sandbox.stub(InstallHandler, 'downloadAndExtract').resolves('path');
+      await InstallHandler.installOc('4.1', 'Windows_NT', false);
+      expect(bundleStub.calledTwice).to.be.true;
+    });
+
     it('check if ocBundle is not called if uri is valid', async function() {
       sandbox.stub(fs, 'existsSync').returns(true);
       const ocBundleStub = sandbox.stub(InstallHandler, 'ocBundleURL');
@@ -47,6 +79,21 @@ describe('InstallHandler', function() {
         false
       );
       expect(ocBundleStub.calledOnce).to.be.false;
+    });
+
+    it('return error if url retrieved by version number is null', async function() {
+      sandbox.stub(fs, 'existsSync').returns(true);
+      sandbox.stub(InstallHandler, 'ocBundleURL')
+              .onFirstCall()
+              .resolves('https://mirror.openshift.com/pub/openshift-v4/clients/oc/3.1/windows/oc.zip')
+              .onSecondCall()
+              .resolves(null);
+      try {
+        await InstallHandler.installOc('4.1', 'Windows_NT', false);
+        expect.fail();
+      } catch(ex) {
+        expect(ex).equals('Unable to determine oc download URL.');
+      }
     });
 
     it('check if task fails if downloadAndExtract doesnt return a valid ocBinary', async function() {
@@ -70,6 +117,20 @@ describe('InstallHandler', function() {
     });
   });
 
+  describe('#latestStable', function() {
+    it('check if null value returned if osType input is not valid', async function() {
+      sandbox.stub(InstallHandler, 'getOcBundleByOS').resolves(null);
+      const res = await InstallHandler.latestStable('fakeOS');
+      expect(res).equals(null);
+    });
+
+    it('check if url returned is valid based on OSType input', async function() {
+      sandbox.stub(InstallHandler, 'getOcBundleByOS').resolves('linux/oc.tar.gz');
+      const res = await InstallHandler.latestStable('linux');
+      expect(res).equals(`${OPENSHIFT_V4_BASE_URL}/${LATEST}/linux/oc.tar.gz`);
+    });
+  });
+
   describe('#ocBundleURL', function() {
     it('should return null when the tag is empty', async function() {
       const result = await InstallHandler.ocBundleURL('', 'Linux');
@@ -79,6 +140,28 @@ describe('InstallHandler', function() {
     it('should return null when the tag is null', async function() {
       const result = await InstallHandler.ocBundleURL(null, 'Linux');
       expect(result).to.be.null;
+    });
+  });
+
+  describe('#getOcBundleByOS', function() {
+    it('return correct value if osType is linux', async function() {
+      const res = await InstallHandler.getOcBundleByOS('Linux');
+      expect(res).equals(`${LINUX}/${OC_TAR_GZ}`);
+    });
+
+    it('return correct value if osType is windows', async function() {
+      const res = await InstallHandler.getOcBundleByOS('Windows_NT');
+      expect(res).equals(`${WIN}/${OC_ZIP}`);
+    });
+
+    it('return correct value if osType is MACOSX', async function() {
+      const res = await InstallHandler.getOcBundleByOS('Darwin');
+      expect(res).equals(`${MACOSX}/${OC_TAR_GZ}`);
+    });
+
+    it('return null if osType is neither linux nor macosx nor windows', async function() {
+      const res = await InstallHandler.getOcBundleByOS('fakeOS');
+      expect(res).equals(null);
     });
   });
 

--- a/test/oc-install.test.ts
+++ b/test/oc-install.test.ts
@@ -50,8 +50,11 @@ describe('InstallHandler', function() {
 
     it('check if ocBundleURl is called if version number is passed as input', async function() {
       sandbox.stub(fs, 'existsSync').returns(true);
-      const bundleStub = sandbox.stub(InstallHandler, 'ocBundleURL')
-                                .resolves('https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.1/windows/oc.zip');
+      const bundleStub = sandbox
+        .stub(InstallHandler, 'ocBundleURL')
+        .resolves(
+          'https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.1/windows/oc.zip'
+        );
       sandbox.stub(InstallHandler, 'downloadAndExtract').resolves('path');
       await InstallHandler.installOc('4.1', 'Windows_NT', false);
       expect(bundleStub.calledOnce).to.be.true;
@@ -59,11 +62,16 @@ describe('InstallHandler', function() {
 
     it('check if ocBundleURl is called twice if version number release as input is not valid', async function() {
       sandbox.stub(fs, 'existsSync').returns(true);
-      const bundleStub = sandbox.stub(InstallHandler, 'ocBundleURL')
-                                .onFirstCall()
-                                .resolves('https://mirror.openshift.com/pub/openshift-v4/clients/oc/3.1/windows/oc.zip')
-                                .onSecondCall()
-                                .resolves('https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.1/windows/oc.zip');
+      const bundleStub = sandbox
+        .stub(InstallHandler, 'ocBundleURL')
+        .onFirstCall()
+        .resolves(
+          'https://mirror.openshift.com/pub/openshift-v4/clients/oc/3.1/windows/oc.zip'
+        )
+        .onSecondCall()
+        .resolves(
+          'https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.1/windows/oc.zip'
+        );
       sandbox.stub(InstallHandler, 'downloadAndExtract').resolves('path');
       await InstallHandler.installOc('4.1', 'Windows_NT', false);
       expect(bundleStub.calledTwice).to.be.true;
@@ -83,15 +91,18 @@ describe('InstallHandler', function() {
 
     it('return error if url retrieved by version number is null', async function() {
       sandbox.stub(fs, 'existsSync').returns(true);
-      sandbox.stub(InstallHandler, 'ocBundleURL')
-              .onFirstCall()
-              .resolves('https://mirror.openshift.com/pub/openshift-v4/clients/oc/3.1/windows/oc.zip')
-              .onSecondCall()
-              .resolves(null);
+      sandbox
+        .stub(InstallHandler, 'ocBundleURL')
+        .onFirstCall()
+        .resolves(
+          'https://mirror.openshift.com/pub/openshift-v4/clients/oc/3.1/windows/oc.zip'
+        )
+        .onSecondCall()
+        .resolves(null);
       try {
         await InstallHandler.installOc('4.1', 'Windows_NT', false);
         expect.fail();
-      } catch(ex) {
+      } catch (ex) {
         expect(ex).equals('Unable to determine oc download URL.');
       }
     });
@@ -125,7 +136,9 @@ describe('InstallHandler', function() {
     });
 
     it('check if url returned is valid based on OSType input', async function() {
-      sandbox.stub(InstallHandler, 'getOcBundleByOS').resolves('linux/oc.tar.gz');
+      sandbox
+        .stub(InstallHandler, 'getOcBundleByOS')
+        .resolves('linux/oc.tar.gz');
       const res = await InstallHandler.latestStable('linux');
       expect(res).equals(`${OPENSHIFT_V4_BASE_URL}/${LATEST}/linux/oc.tar.gz`);
     });

--- a/test/oc-install.test.ts
+++ b/test/oc-install.test.ts
@@ -29,46 +29,12 @@ describe('InstallHandler', function() {
     it('check if latestStable method is called if no ocVersion is passed', async function() {
       const latestStub = sandbox
         .stub(InstallHandler, 'latestStable')
-        .resolves('path');
+        .resolves('http://url.com/ocbundle');
       sandbox.stub(fs, 'existsSync').returns(true);
       sandbox.stub(InstallHandler, 'ocBundleURL').resolves('url');
       sandbox.stub(InstallHandler, 'downloadAndExtract').resolves('path');
       await InstallHandler.installOc('', 'Darwin', false);
       expect(latestStub.calledOnce).to.be.true;
-    });
-
-    it('check if latestStable method is not called if ocVersion is passed', async function() {
-      const latestStub = sandbox
-        .stub(InstallHandler, 'latestStable')
-        .resolves('path');
-      sandbox.stub(fs, 'existsSync').returns(true);
-      sandbox.stub(InstallHandler, 'ocBundleURL').resolves('url');
-      sandbox.stub(InstallHandler, 'downloadAndExtract').resolves('path');
-      await InstallHandler.installOc('version', 'Darwin', false);
-      expect(latestStub.calledOnce).to.be.false;
-    });
-
-    it('check if ocBundleUrl is correctly called if no valid url is passed', async function() {
-      sandbox.stub(fs, 'existsSync').returns(true);
-      sandbox.stub(validUrl, 'isWebUri').returns('');
-      const ocBundleStub = sandbox
-        .stub(InstallHandler, 'ocBundleURL')
-        .resolves('url');
-      sandbox.stub(InstallHandler, 'downloadAndExtract').resolves('path');
-      await InstallHandler.installOc('v3.10.0', 'Darwin', false);
-      expect(ocBundleStub.calledOnce).to.be.true;
-    });
-
-    it('check if method returns a null value if url is not valid', async function() {
-      sandbox.stub(fs, 'existsSync').returns(true);
-      sandbox.stub(validUrl, 'isWebUri').returns('');
-      sandbox.stub(InstallHandler, 'ocBundleURL').resolves(null);
-      try {
-        await InstallHandler.installOc('path', 'Darwin', false);
-        expect.fail();
-      } catch (ex) {
-        expect(ex).equals('Unable to determine oc download URL.');
-      }
     });
 
     it('check if ocBundle is not called if uri is valid', async function() {


### PR DESCRIPTION
it fixes #115 

@jeffmaury it works this way.

If the user use a non-valid release such as 3.11.0 then the latest release for that version will be downloaded (3.11.154). If the user use a valid release as input then that version will be used (so if user wants, he will still be able to use an intermediate version such as 3.11.56). Also versions >4 are supported. In this case it's easier bc ppl just need to insert 4.1/4.2/4.3 . This patch also managed the letter v which was used previously so after the update old pipeline with inputs like 'v3.11.0' still work. I removed completely git API calls so there won't be any exceeding API limit error anymore.