### PR TITLE
updated node version and node types deps

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,9 +10,9 @@ jobs:
       demands: npm
     steps:
       - task: NodeTool@0
-        displayName: 'Use Node 10.x'
+        displayName: 'Use Node 13.x'
         inputs:
-          versionSpec: 10.16.0
+          versionSpec: 13.0.1
       - task: Npm@1
         displayName: 'Install dependencies'
         inputs:
@@ -41,9 +41,9 @@ jobs:
       demands: npm
     steps:
       - task: NodeTool@0
-        displayName: 'Use Node 10.x'
+        displayName: 'Use Node 13.x'
         inputs:
-          versionSpec: 10.16.0
+          versionSpec: 13.0.1
       - task: Npm@1
         displayName: 'Install dependencies'
         inputs:
@@ -71,9 +71,9 @@ jobs:
       name: Hosted Ubuntu 1604
     steps:
       - task: NodeTool@0
-        displayName: 'Use Node 10.x'
+        displayName: 'Use Node 13.x'
         inputs:
-          versionSpec: 10.16.0
+          versionSpec: 13.0.1
       - task: Npm@1
         displayName: 'Install dependencies'
         inputs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,9 +115,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.12.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.1.tgz",
-      "integrity": "sha512-i1sl+WCX2OCHeUi9oi7PiCNUtYFrpWhpcx878vpeq/tlZTKzcFdHePlyFHVbWqeuKN0SRPl/9ZFDSTsfv9h7VQ=="
+      "version": "12.12.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.7.tgz",
+      "integrity": "sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w=="
     },
     "@types/q": {
       "version": "1.5.1",
@@ -996,12 +996,6 @@
       "requires": {
         "is-plain-object": "^2.0.4"
       }
-    },
-    "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -2270,38 +2264,6 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
-    },
-    "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "dev": true,
-      "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        }
-      }
     },
     "wrap-ansi": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@types/chai": "^4.1.6",
     "@types/glob": "^7.1.1",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.11.6",
+    "@types/node": "^12.12.7",
     "@types/sinon": "^7.0.13",
     "chai": "^4.2.0",
     "chai-fs": "^2.0.0",


### PR DESCRIPTION
There is a problem when running a pipeline in Windows on Azure by using node version 10.x.

```
npm ERR! path C:\npm\prefix\tsc.cmd
npm ERR! code EEXIST
npm ERR! Refusing to delete C:\npm\prefix\tsc.cmd: is outside C:\npm\prefix\node_modules\typescript and not a link
npm ERR! File exists: C:\npm\prefix\tsc.cmd
npm ERR! Move it away, and try again.
```

It worked until thursday so i guess they updated something which introduced this error. By using a newer node version it started working again