### PR TITLE
[WIP] use inline config or config file for oc

### DIFF
--- a/src/config-map-task.ts
+++ b/src/config-map-task.ts
@@ -24,7 +24,7 @@ async function run(): Promise<void> {
   const properties = task.getInput('properties');
   const configMap = new ConfigMap(configMapName, properties);
 
-  await auth.createKubeConfig(auth.getOpenShiftEndpoint(), ocPath, agentOS);
+  await auth.createKubeConfig(ocPath, agentOS);
   await RunnerHandler.execOc(ocPath, configMap.patchCmd(namespace));
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,13 @@ export const LATEST = 'latest';
 export const OC_TAR_GZ = 'oc.tar.gz';
 export const OC_ZIP = 'oc.zip';
 
+export const CONNECTION_TYPE_SELECTION = 'connectionType';
+export const OPENSHIFT_SERVICE_OPTION = 'OpenShift Connection Service';
+export const FILE_CONFIGURATION_OPTION = 'File Configuration';
+export const INLINE_CONFIGURATION_OPTION = 'Inline Configuration';
 export const OPENSHIFT_SERVICE_NAME = 'openshiftService';
+export const CONFIGURATION_PATH = 'configurationPath';
+export const INLINE_CONFIG = 'inlineConfig';
 export const BASIC_AUTHENTICATION = 'UsernamePassword';
 export const TOKEN_AUTHENTICATION = 'Token';
 export const NO_AUTHENTICATION = 'None';

--- a/src/oc-auth.ts
+++ b/src/oc-auth.ts
@@ -147,7 +147,10 @@ export function exportKubeConfig(osType: string): void {
  * @param ocPath fully qualified path to the oc binary.
  * @param osType the OS type. One of 'Linux', 'Darwin' or 'Windows_NT'.
  */
-export async function createKubeConfigFromServiceConnection(ocPath: string, osType: string) {
+export async function createKubeConfigFromServiceConnection(
+  ocPath: string,
+  osType: string
+): Promise<void> {
   const endpoint = getOpenShiftEndpoint();
   if (endpoint === null) {
     throw new Error('null endpoint is not allowed');

--- a/src/oc-exec-task.ts
+++ b/src/oc-exec-task.ts
@@ -26,7 +26,7 @@ async function run(): Promise<void> {
     throw new Error('no oc binary found');
   }
 
-  await auth.createKubeConfig(auth.getOpenShiftEndpoint(), ocPath, agentOS);
+  await auth.createKubeConfig(ocPath, agentOS);
   await RunnerHandler.execOc(ocPath, argLine, ignoreFlag);
 }
 

--- a/src/oc-setup-task.ts
+++ b/src/oc-setup-task.ts
@@ -16,7 +16,7 @@ async function run(): Promise<void> {
     throw new Error('no oc binary found');
   }
   InstallHandler.addOcToPath(ocPath, agentOS);
-  await auth.createKubeConfig(auth.getOpenShiftEndpoint(), ocPath, agentOS);
+  await auth.createKubeConfig(ocPath, agentOS);
 }
 
 run()

--- a/tasks/config-map/task.json
+++ b/tasks/config-map/task.json
@@ -12,20 +12,73 @@
   ],
   "preview": true,
   "demands": [],
+  "groups": [
+    {
+      "name": "openshiftCluster",
+      "displayName": "OpenShift Cluster",
+      "isExpanded": true
+    },
+    {
+      "name": "commands",
+      "displayName": "Commands",
+      "isExpanded": true
+    }
+  ],
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 12
+    "Patch": 13
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "config-map $(message)",
   "inputs": [
     {
+      "name": "connectionType",
+      "type": "pickList",
+      "label": "Service connection type",
+      "defaultValue": "OpenShift Connection Service",
+      "required": true,
+      "options": {
+        "OpenShift Connection Service": "OpenShift Connection Service",
+        "File Configuration": "File Configuration",
+        "Inline Configuration": "Inline Configuration"
+      },
+      "groupName": "openshiftCluster",
+      "helpMarkDown": "Select a service connection type."
+    },
+    {
       "name": "openshiftService",
       "type": "connectedService:openshift",
       "label": "OpenShift service connection",
+      "visibleRule": "connectionType = OpenShift Connection Service",
+      "helpMarkDown": "Select OpenShift service connection to use.",
+      "groupName": "openshiftCluster",
+      "required": true
+    },
+    {
+      "name": "configurationPath",
+      "type": "filePath",
+      "label": "File path",
+      "defaultValue": "",
       "required": true,
-      "helpMarkDown": "Select OpenShift service connection to use."
+      "helpMarkDown": "Filename, directory, or URL to the kubeconfig file that will be used with the commands.",
+      "groupName": "openshiftCluster",
+      "visibleRule": "connectionType = File Configuration"
+    },
+    {
+      "name": "inlineConfig",
+      "type": "multiLine",
+      "properties": {
+        "resizable": "true",
+        "rows": "10",
+        "maxLength": "5000"
+      },
+      "required": true,
+      "defaultValue": "",
+      "label": "Inline configuration",
+      "helpMarkDown": "Inline kubeconfig for oc command",
+      "groupName": "openshiftCluster",
+      "visibleRule": "connectionType = Inline Configuration"
     },
     {
       "name": "version",
@@ -33,6 +86,7 @@
       "label": "Version of oc",
       "defaultValue": "",
       "required": false,
+      "groupName": "commands",
       "helpMarkDown": "Select the oc version to use e.g. 'v3.10.0' (leave blank for latest). You can also specify a direct URL to a oc release bundle."
     },
     {
@@ -41,6 +95,7 @@
       "label": "Name of the ConfigMap",
       "defaultValue": "",
       "required": true,
+      "groupName": "commands",
       "helpMarkDown": "Name of the ConfigMap to which to apply the properties."
     },
     {
@@ -49,6 +104,7 @@
       "label": "Namespace of ConfigMap",
       "defaultValue": "",
       "required": false,
+      "groupName": "commands",
       "helpMarkDown": "Specify the namespace of the ConfigName. If none is specified the current namespace is used."
     },
     {
@@ -58,6 +114,7 @@
       "defaultValue": "",
       "required": false,
       "helpMarkDown": "To view the ConfigMap parameters in a grid, click on “…” next to the textbox.",
+      "groupName": "commands",
       "properties": {
         "editorExtension": "ms.vss-services-azure.parameters-grid"
       }
@@ -68,6 +125,7 @@
       "label": "Use local oc executable",
       "defaultValue": "false",
       "required": false,
+      "groupName": "commands",
       "helpMarkDown": "Check if oc is already installed in the machine and use that if available"
     },
     {
@@ -76,6 +134,7 @@
       "label": "Use proxy to download oc executable",
       "defaultValue": "",
       "required": false,
+      "groupName": "commands",
       "helpMarkDown": "make use of a proxy to download oc executable"
     }
   ],

--- a/tasks/oc-cmd/task.json
+++ b/tasks/oc-cmd/task.json
@@ -12,20 +12,72 @@
   ],
   "preview": true,
   "demands": [],
+  "groups": [{
+      "name": "openshiftCluster",
+      "displayName": "OpenShift Cluster",
+      "isExpanded": true
+    },
+    {
+      "name": "commands",
+      "displayName": "Commands",
+      "isExpanded": true
+    }
+  ],
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 12
+    "Patch": 13
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "oc-cmd $(message)",
   "inputs": [
     {
+      "name": "connectionType",
+      "type": "pickList",
+      "label": "Service connection type",
+      "defaultValue": "OpenShift Connection Service",
+      "required": true,
+      "options": {
+        "OpenShift Connection Service": "OpenShift Connection Service",
+        "File Configuration": "File Configuration",
+        "Inline Configuration": "Inline Configuration"
+      },
+      "groupName": "openshiftCluster",
+      "helpMarkDown": "Select a service connection type."
+    },
+    {
       "name": "openshiftService",
       "type": "connectedService:openshift",
       "label": "OpenShift service connection",
+      "visibleRule": "connectionType = OpenShift Connection Service",
+      "helpMarkDown": "Select OpenShift service connection to use.",
+      "groupName": "openshiftCluster",
+      "required": true
+    },
+    {
+      "name": "configurationPath",
+      "type": "filePath",
+      "label": "File path",
+      "defaultValue": "",
       "required": true,
-      "helpMarkDown": "Select OpenShift service connection to use."
+      "helpMarkDown": "Filename, directory, or URL to the kubeconfig file that will be used with the commands.",
+      "groupName": "openshiftCluster",
+      "visibleRule": "connectionType = File Configuration"
+    },
+    {
+      "name": "inlineConfig",
+      "type": "multiLine",
+      "properties": {
+        "resizable": "true",
+        "rows": "10",
+        "maxLength": "5000"
+      },
+      "required": true,
+      "defaultValue": "",
+      "label": "Inline configuration",
+      "helpMarkDown": "Inline kubeconfig for oc command",
+      "groupName": "openshiftCluster",
+      "visibleRule": "connectionType = Inline Configuration"
     },
     {
       "name": "version",
@@ -33,6 +85,7 @@
       "label": "Version of oc to use",
       "defaultValue": "",
       "required": false,
+      "groupName": "commands",
       "helpMarkDown": "Select the oc version to use e.g. 'v3.10.0' (leave blank for latest). You can also specify a direct URL to a oc release bundle."
     },
     {
@@ -41,6 +94,7 @@
       "label": "Command to run",
       "defaultValue": "",
       "required": true,
+      "groupName": "commands",
       "helpMarkDown": "Specify the oc command to run."
     },
     {
@@ -49,14 +103,16 @@
       "label": "Ignore non success return value",
       "defaultValue": "false",
       "required": false,
+      "groupName": "commands",
       "helpMarkDown": "Specify if the non success return value of the oc command run has to be ignored. E.g if the command oc create/delete/... fail because the resource has already been created/deleted/.. the pipeline will continue its execution"
-    }, 
+    },
     {
       "name": "uselocalOc",
       "type": "boolean",
       "label": "Use local oc executable",
       "defaultValue": "false",
       "required": false,
+      "groupName": "commands",
       "helpMarkDown": "Check if oc is already installed in the machine and use that if available"
     },
     {
@@ -65,6 +121,7 @@
       "label": "Use proxy to download oc executable",
       "defaultValue": "",
       "required": false,
+      "groupName": "commands",
       "helpMarkDown": "make use of a proxy to download oc executable"
     }
   ],

--- a/tasks/oc-setup/task.json
+++ b/tasks/oc-setup/task.json
@@ -12,20 +12,73 @@
   ],
   "preview": true,
   "demands": [],
+  "groups": [
+    {
+      "name": "openshiftCluster",
+      "displayName": "OpenShift Cluster",
+      "isExpanded": true
+    },
+    {
+      "name": "commands",
+      "displayName": "Commands",
+      "isExpanded": true
+    }
+  ],
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 12
+    "Patch": 13
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "oc-setup $(message)",
   "inputs": [
     {
+      "name": "connectionType",
+      "type": "pickList",
+      "label": "Service connection type",
+      "defaultValue": "OpenShift Connection Service",
+      "required": true,
+      "options": {
+        "OpenShift Connection Service": "OpenShift Connection Service",
+        "File Configuration": "File Configuration",
+        "Inline Configuration": "Inline Configuration"
+      },
+      "groupName": "openshiftCluster",
+      "helpMarkDown": "Select a service connection type."
+    },
+    {
       "name": "openshiftService",
       "type": "connectedService:openshift",
       "label": "OpenShift service connection",
+      "visibleRule": "connectionType = OpenShift Connection Service",
+      "helpMarkDown": "Select OpenShift service connection to use.",
+      "groupName": "openshiftCluster",
+      "required": true
+    },
+    {
+      "name": "configurationPath",
+      "type": "filePath",
+      "label": "File path",
+      "defaultValue": "",
       "required": true,
-      "helpMarkDown": "Select OpenShift service connection to use."
+      "helpMarkDown": "Filename, directory, or URL to the kubeconfig file that will be used with the commands.",
+      "groupName": "openshiftCluster",
+      "visibleRule": "connectionType = File Configuration"
+    },
+    {
+      "name": "inlineConfig",
+      "type": "multiLine",
+      "properties": {
+        "resizable": "true",
+        "rows": "10",
+        "maxLength": "5000"
+      },
+      "required": true,
+      "defaultValue": "",
+      "label": "Inline configuration",
+      "helpMarkDown": "Inline kubeconfig for oc command",
+      "groupName": "openshiftCluster",
+      "visibleRule": "connectionType = Inline Configuration"
     },
     {
       "name": "version",
@@ -33,6 +86,7 @@
       "label": "Version of oc",
       "defaultValue": "",
       "required": false,
+      "groupName": "commands",
       "helpMarkDown": "Select the oc version to use e.g. 'v3.10.0' (leave blank for latest). You can also specify a direct URL to a oc release bundle."
     },
     {
@@ -41,6 +95,7 @@
       "label": "Use proxy to download oc executable",
       "defaultValue": "",
       "required": false,
+      "groupName": "commands",
       "helpMarkDown": "make use of a proxy to download oc executable"
     }
   ],

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "openshift-vsts",
   "publisher": "redhat",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "name": "OpenShift Extension",
   "description": "OpenShift tasks for Azure DevOps",
   "public": true,

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "openshift-vsts",
   "publisher": "redhat",
-  "version": "1.4.3",
+  "version": "1.5.1",
   "name": "OpenShift Extension",
   "description": "OpenShift tasks for Azure DevOps",
   "public": true,


### PR DESCRIPTION
This resolves issue #146 and adds the possibility to use **your own configuration file** and or **use inline configuration** (similar to kubectl task).

Kept it at WIP as if those changes are wanted I'd update the documentation accordingly