### PR TITLE
added cache implementation (#151)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -163,11 +163,21 @@
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.1.tgz",
       "integrity": "sha512-eqz8c/0kwNi/OEHQfvIuJVLTst3in0e7uTKeuY+WL/zfKn0xVujOTp42bS/vUUokhK5P2BppLd9JXMOMHcgbjA=="
     },
+    "@types/semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
+    },
     "@types/sinon": {
       "version": "7.0.13",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.0.13.tgz",
       "integrity": "sha512-d7c/C/+H/knZ3L8/cxhicHUiTDxdgap0b/aNJfsmLwFu/iOP17mdgbQsbHA3SJmrzsjD0l3UEE5SN4xxuz5ung==",
       "dev": true
+    },
+    "@types/uuid": {
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.8.tgz",
+      "integrity": "sha512-zHWce3allXWSmRx6/AGXKCtSOA7JjeWd2L3t4aHfysNk8mouQnWCocveaT7a4IEIlPVHp81jzlnknqTgCjCLXA=="
     },
     "@types/valid-url": {
       "version": "1.0.2",
@@ -439,6 +449,34 @@
         "semver": "^5.1.0",
         "shelljs": "^0.3.0",
         "uuid": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
+    "azure-pipelines-tool-lib": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-0.12.0.tgz",
+      "integrity": "sha512-JAlFvMTtEXISrnJY/kgq0LecLi089RqXRf/gMsXYbflmzszklkc+LUJpR0A7NDmJ+9/MWpKY/ZX+Q/zirYa7gw==",
+      "requires": {
+        "@types/semver": "^5.3.0",
+        "@types/uuid": "^3.0.1",
+        "azure-pipelines-task-lib": "^2.8.0",
+        "semver": "^5.3.0",
+        "semver-compare": "^1.0.0",
+        "typed-rest-client": "1.0.9",
+        "uuid": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "balanced-match": {
@@ -754,6 +792,14 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "crypt": {
@@ -2481,6 +2527,12 @@
           "requires": {
             "path-parse": "^1.0.6"
           }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -2623,6 +2675,14 @@
             "semver": "^5.5.0",
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true
+            }
           }
         },
         "execa": {
@@ -3181,9 +3241,14 @@
       }
     },
     "semver": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
+      "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA=="
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -3630,6 +3695,11 @@
         "tslib": "^1.8.1"
       }
     },
+    "tunnel": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -3650,6 +3720,15 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
+    },
+    "typed-rest-client": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.0.9.tgz",
+      "integrity": "sha512-iOdwgmnP/tF6Qs+oY4iEtCf/3fnCDl7Gy9LGPJ4E3M4Wj3uaSko15FVwbsaBmnBqTJORnXBWVY5306D4HH8oiA==",
+      "requires": {
+        "tunnel": "0.0.4",
+        "underscore": "1.8.3"
+      }
     },
     "typescript": {
       "version": "3.7.5",
@@ -3685,6 +3764,11 @@
         "buffer": "^3.0.1",
         "through": "^2.3.6"
       }
+    },
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
     "universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -61,10 +61,12 @@
     "adm-zip": "^0.4.13",
     "argv-split": "^2.0.1",
     "azure-pipelines-task-lib": "^2.9.3",
+    "azure-pipelines-tool-lib": "^0.12.0",
     "decompress": "^4.2.0",
     "decompress-targz": "^4.1.1",
     "node-fetch": "^2.6.0",
     "q": "^1.5.1",
+    "semver": "^7.1.3",
     "substituter": "^1.3.0",
     "valid-url": "^1.0.9"
   },

--- a/test/oc-install.test.ts
+++ b/test/oc-install.test.ts
@@ -189,6 +189,7 @@ describe('InstallHandler', () => {
         '',
         'path',
         'Linux',
+        '',
         'ip:port'
       );
       expect(res).to.be.null;
@@ -202,6 +203,7 @@ describe('InstallHandler', () => {
           'url',
           'path',
           'Linux',
+          '',
           'ip:port'
         );
         normalizeStub.calledOnce;
@@ -221,7 +223,7 @@ describe('InstallHandler', () => {
         .returns(false);
       const toolStub = sandbox.stub(tl, 'tool').returns(stubs.tr);
       try {
-        await InstallHandler.downloadAndExtract('url', 'path', 'Linux', '');
+        await InstallHandler.downloadAndExtract('url', 'path', 'Linux', '', '');
       } catch (ex) {}
       sinon.assert.calledWith(toolStub, 'curl');
       expect(stubs.args.length).equals(5);
@@ -241,6 +243,7 @@ describe('InstallHandler', () => {
           'url',
           'path',
           'Linux',
+          '',
           'ip:port'
         );
       } catch (ex) {}
@@ -263,6 +266,7 @@ describe('InstallHandler', () => {
         'url',
         'path',
         'Linux',
+        '',
         'ip:port'
       );
       expect(res).equals(null);
@@ -285,6 +289,7 @@ describe('InstallHandler', () => {
         'url',
         'path',
         'Windows_NT',
+        '',
         'ip:port'
       );
       expect(res).equals('path/oc.exe');
@@ -307,6 +312,7 @@ describe('InstallHandler', () => {
         'url',
         'path',
         'Linux',
+        '',
         'ip:port'
       );
       expect(res).equals('path/oc');
@@ -397,7 +403,7 @@ describe('InstallHandler', () => {
     it('returns nothing if oc path exists but oc version cannot be retrieved', () => {
       sandbox.stub(tl, 'which').returns('path');
       const getOcStub = sandbox
-        .stub(InstallHandler, 'getOcVersion')
+        .stub(InstallHandler, 'getVersionFromExecutable')
         .returns(undefined);
       const res = InstallHandler.getLocalOcPath('1.1');
       sinon.assert.calledWith(getOcStub, 'path');
@@ -406,13 +412,13 @@ describe('InstallHandler', () => {
 
     it('returns nothing if version found locally is not the one user wants to use', () => {
       sandbox.stub(tl, 'which').returns('path');
-      sandbox.stub(InstallHandler, 'getOcVersion').returns('2.1');
+      sandbox.stub(InstallHandler, 'getVersionFromExecutable').returns('2.1');
       const res = InstallHandler.getLocalOcPath('1.1');
       expect(res).equals(undefined);
     });
   });
 
-  describe('#getOcVersion', () => {
+  describe('#getVersionFromExecutable', () => {
     const versionRes: IExecSyncResult = {
       code: 1,
       error: undefined,
@@ -427,7 +433,7 @@ describe('InstallHandler', () => {
 
     it('check if correct version is returned if oc version > 4', () => {
       execOcStub.returns(versionRes);
-      const res = InstallHandler.getOcVersion('path');
+      const res = InstallHandler.getVersionFromExecutable('path');
       expect(res).equals('v4.1.0');
     });
 
@@ -437,7 +443,7 @@ describe('InstallHandler', () => {
         .returns(undefined)
         .onSecondCall()
         .returns(undefined);
-      InstallHandler.getOcVersion('path');
+      InstallHandler.getVersionFromExecutable('path');
       sinon.assert.calledTwice(execOcStub);
     });
 
@@ -448,7 +454,7 @@ describe('InstallHandler', () => {
         .returns(undefined)
         .onSecondCall()
         .returns(versionRes);
-      const res = InstallHandler.getOcVersion('path');
+      const res = InstallHandler.getVersionFromExecutable('path');
       expect(res).equals('v3.2.0');
     });
 
@@ -458,7 +464,7 @@ describe('InstallHandler', () => {
         .returns(undefined)
         .onSecondCall()
         .returns(undefined);
-      const res = InstallHandler.getOcVersion('path');
+      const res = InstallHandler.getVersionFromExecutable('path');
       expect(res).equals(undefined);
     });
 
@@ -469,14 +475,14 @@ describe('InstallHandler', () => {
         .returns(undefined)
         .onSecondCall()
         .returns(versionRes);
-      const res = InstallHandler.getOcVersion('path');
+      const res = InstallHandler.getVersionFromExecutable('path');
       expect(res).equals(undefined);
     });
 
     it('returns undefined if execOcSync returns a not empty stdout without a valid version in it', () => {
       versionRes.stdout = 'xxxxx xxxxx xxxxxx xxxxxx xxxxx';
       execOcStub.returns(versionRes);
-      const res = InstallHandler.getOcVersion('path');
+      const res = InstallHandler.getVersionFromExecutable('path');
       expect(res).equals(undefined);
     });
   });


### PR DESCRIPTION
it fixes #151

Eventually i used the cache from vsts tool lib. It takes care of the version used and check if the executable has been correctly downloaded.

The issue here was the location where the oc executable was downloaded. The /1/s folder is deleted and recreated every run and it forced to download a new oc when a new pipeline is started. Until now the only way to prevent downloading a new oc between different pipelines was to use the oc already present in the machine. 