### PR TITLE
Add interpolate command support

### DIFF
--- a/src/oc-exec.ts
+++ b/src/oc-exec.ts
@@ -30,13 +30,15 @@ export class RunnerHandler {
 
     // substitute internal commands
     argLine = RunnerHandler.interpolateCommands(ocPath, argLine);
+    if (!argLine) {
+      return Promise.reject(new Error(`Failed to interpolate internal commands in ${argLine}`));
+    }
 
     // split cmd based on redirection operators
     const cmds: string[] = argLine.split(/(?=2(?=>))|(?=[>|])/);
     const trs: ToolRunner[] = RunnerHandler.initToolRunners(cmds, ocPath);
     if (trs === []) {
-      tl.debug(`Unable to create any ToolRunner by ${argLine}`);
-      return;
+      return Promise.reject(new Error(`Unable to create any ToolRunner by ${argLine}`));
     }
     const tr: ToolRunner = RunnerHandler.unifyToolRunners(cmds, trs, options);
     await tr.exec(options);

--- a/src/oc-exec.ts
+++ b/src/oc-exec.ts
@@ -219,7 +219,7 @@ export class RunnerHandler {
    */
   static interpolateCommands(ocPath: string, argLine: string): string {
     // check if there are internal commands to be sustituted with their result
-    const cmdsToSubstitute: RegExpMatchArray = RunnerHandler.matchInternalCommands(argLine);
+    const cmdsToSubstitute: string[] = RunnerHandler.matchInternalCommands(argLine);
     if (cmdsToSubstitute.length === 0) {
       return argLine;
     }


### PR DESCRIPTION
This PR adds interpolation support for commands inside a command. This means that users can now execute commands such as `oc logs $(oc get pods -l app=test -o name)`
