### PR TITLE
fix: wrong bundle name cached in windows (#193)

### DIFF
--- a/src/oc-install.ts
+++ b/src/oc-install.ts
@@ -245,7 +245,9 @@ export class InstallHandler {
     }
 
     fs.chmodSync(ocBinary, '0755');
-    if (versionToCache) await toolLib.cacheFile(ocBinary, 'oc', 'oc', versionToCache);
+    if (versionToCache) {
+      await toolLib.cacheFile(ocBinary, InstallHandler.ocBinaryByOS(osType), 'oc', versionToCache);
+    }
     return { found: true, path: ocBinary };
   }
 


### PR DESCRIPTION
it resolves #193 