### PR TITLE
fix: added '.gz' case to unzipArchive method to avoid 'unknown archive format' error (#212)

### DIFF
--- a/src/utils/zip_helper.ts
+++ b/src/utils/zip_helper.ts
@@ -25,6 +25,7 @@ export async function unzipArchive(
       });
       break;
     }
+    case '.gz':
     case '.tgz':
     case '.tar.gz': {
       await decompress(archivePath, downloadDir, {


### PR DESCRIPTION
This PR fixes the issue #212